### PR TITLE
Don't convert the file to a string after reading

### DIFF
--- a/lib/sftpHelper.js
+++ b/lib/sftpHelper.js
@@ -25,7 +25,7 @@ sftp: SFTP client from ssh2, assumed to already be promisified.
 dir: The directory where the file lives.
 fileName: The file to be written, should not include any of the directory path. Can
   optionally be the file's info (from readdir), for efficiency.
-process: A function with one argument, the body of the file as a string.
+process: A function with one argument, the body of the file as a Buffer.
 */
 exports.processFile = function(sftp, dir, fileName, process) {
   return Promise.try(function() {
@@ -44,7 +44,7 @@ exports.processFile = function(sftp, dir, fileName, process) {
       var result = new Buffer(fileInfo.attrs.size);
       return sftp.readAsync(handle, result, 0, fileInfo.attrs.size, 0)
       .then(function(data) {
-        return process(result.toString());
+        return process(result);
       })
       .then(function(data) {
         return sftp.closeAsync(handle)


### PR DESCRIPTION
Strings in node have a length limit of 256MiB, so before this change, it was unable to copy files larger than 256MiB.

The S3 SDK can handle a Buffer just as well as a string, so there is no need to convert the file body to a string.