### PR TITLE
Call readAsync multiple times, until entire file is read

### DIFF
--- a/lib/sftpHelper.js
+++ b/lib/sftpHelper.js
@@ -20,6 +20,17 @@ exports.getSshClient = function(config) {
   });
 }
 
+function readEntireSize(sftp, handle, buffer, offset, size) {
+  return sftp.readAsync(handle, buffer, offset, size - offset, offset)
+  .then(function(bytesRead) {
+    if (bytesRead == size - offset) {
+      return null;
+    } else {
+      return readEntireSize(sftp, handle, buffer, offset + bytesRead, size);
+    }
+  });
+}
+
 /*
 sftp: SFTP client from ssh2, assumed to already be promisified.
 dir: The directory where the file lives.
@@ -42,8 +53,8 @@ exports.processFile = function(sftp, dir, fileName, process) {
     return sftp.openAsync(dir + '/' + fileInfo.filename, 'r')
     .then(function(handle) {
       var result = new Buffer(fileInfo.attrs.size);
-      return sftp.readAsync(handle, result, 0, fileInfo.attrs.size, 0)
-      .then(function(data) {
+      return readEntireSize(sftp, handle, result, 0, fileInfo.attrs.size)
+      .then(function() {
         return process(result);
       })
       .then(function(data) {


### PR DESCRIPTION
It's not guaranteed to return the entire file contents in a single call -- the size you pass to readAsync is a maximum, and the server can choose to return less than the requested amount.

So with some types of servers, without this fix, copying a large file can result in getting a file that has a chunk of correct data at the start and the rest is just zeros.