### PR TITLE
Adding Log Group to fix Issue #2

### DIFF
--- a/cloud_formation/s3-sftp-bridge-deploy-to-vpc.template
+++ b/cloud_formation/s3-sftp-bridge-deploy-to-vpc.template
@@ -186,6 +186,13 @@
         "BridgeResourcePolicy"
       ]
     },
+    "LambdaLogGroup": {
+      "Type" : "AWS::Logs::LogGroup",
+      "Properties" : {
+        "LogGroupName": { "Fn::Join": [ "", [ "/aws/lambda/", { "Ref": "BridgeFunction" } ] ] },
+        "RetentionInDays" : 7
+      }
+    },
     "FunctionTimeoutMetric": {
       "Type": "AWS::Logs::MetricFilter",    
       "Properties": {
@@ -200,7 +207,7 @@
         ]
       },
       "DependsOn": [
-        "BridgeFunction"
+        "BridgeFunction", "LambdaLogGroup"
       ]
     },
     "ConnectionTimeoutMetric": {
@@ -217,7 +224,7 @@
         ]
       },
       "DependsOn": [
-        "BridgeFunction"
+        "BridgeFunction", "LambdaLogGroup"
       ]
     },
     "ErrorMetric": {
@@ -234,7 +241,7 @@
         ]
       },
       "DependsOn": [
-        "BridgeFunction"
+        "BridgeFunction", "LambdaLogGroup"
       ]
     },
     "S3toSFTPMetric": {
@@ -251,7 +258,7 @@
         ]
       },
       "DependsOn": [
-        "BridgeFunction"
+        "BridgeFunction", "LambdaLogGroup"
       ]
     },
     "SFTPtoS3Metric": {
@@ -268,7 +275,7 @@
         ]
       },
       "DependsOn": [
-        "BridgeFunction"
+        "BridgeFunction", "LambdaLogGroup"
       ]
     }
   },

--- a/cloud_formation/s3-sftp-bridge-deploy.template
+++ b/cloud_formation/s3-sftp-bridge-deploy.template
@@ -154,6 +154,13 @@
         "BridgeResourcePolicy"
       ]
     },
+    "LambdaLogGroup": {
+      "Type" : "AWS::Logs::LogGroup",
+      "Properties" : {
+        "LogGroupName": { "Fn::Join": [ "", [ "/aws/lambda/", { "Ref": "BridgeFunction" } ] ] },
+        "RetentionInDays" : 7
+      }
+    },
     "FunctionTimeoutMetric": {
       "Type": "AWS::Logs::MetricFilter",    
       "Properties": {
@@ -168,7 +175,7 @@
         ]
       },
       "DependsOn": [
-        "BridgeFunction"
+        "BridgeFunction", "LambdaLogGroup"
       ]
     },
     "ConnectionTimeoutMetric": {
@@ -185,7 +192,7 @@
         ]
       },
       "DependsOn": [
-        "BridgeFunction"
+        "BridgeFunction", "LambdaLogGroup"
       ]
     },
     "ErrorMetric": {
@@ -202,7 +209,7 @@
         ]
       },
       "DependsOn": [
-        "BridgeFunction"
+        "BridgeFunction", "LambdaLogGroup"
       ]
     },
     "S3toSFTPMetric": {
@@ -219,7 +226,7 @@
         ]
       },
       "DependsOn": [
-        "BridgeFunction"
+        "BridgeFunction", "LambdaLogGroup"
       ]
     },
     "SFTPtoS3Metric": {
@@ -236,7 +243,7 @@
         ]
       },
       "DependsOn": [
-        "BridgeFunction"
+        "BridgeFunction", "LambdaLogGroup"
       ]
     }
   },


### PR DESCRIPTION
I had the same issue as
- https://github.com/gilt/s3-sftp-bridge/issues/2

Here is a PR for both the vpc and non-vpc cloudformation templates. I tested this for both the vpc and non-vpc templates. They both work.