### PR TITLE
Feature multiple s3 locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ bucket-name
 bucket-name/sub-directory
 bucket-name/sub/directory
 
+You can also provide an array of S3 locations if you want to sync an origin directory to multiple destination directories.
+Ex:
+[bucket-name, bucket2-name/subdirectory, bucket3-name/sub/directory]
+
 ### sftpConfig
 A JSON object that contains any of the connection options listed here: https://www.npmjs.com/package/ssh2#client-methods.
 

--- a/lib/sftpHelper.js
+++ b/lib/sftpHelper.js
@@ -58,6 +58,7 @@ exports.processFile = function(sftp, dir, fileName, process) {
           if (!dirList.find(function(item) { return item.filename == exports.DoneDir})) return sftp.mkdirAsync(dir + '/' + exports.DoneDir);
         })
         .then(function() {
+          console.log("Moving " + dir + "/" + fileInfo.filename + " to .done directory...");
           return sftp.renameAsync(dir + '/' + fileInfo.filename, dir + '/' + exports.DoneDir + '/' + getCurrentTimestamp() + '-' + fileInfo.filename);
         })
         .then(function() {

--- a/test/mainTest.js
+++ b/test/mainTest.js
@@ -155,6 +155,19 @@ describe('main', function() {
         }
       );
     });
+
+    it('should copy a file to multiple s3 locations', function() {
+      testHelper.env.CONFIG = '{"test-stream1":{"sftpLocation":"dir/subdir","sftpConfig":{},"s3Location":["my-bucket1","my-bucket2/subdir"]}}';
+      testHelper.sftp.objects['dir/subdir/my-file.txt'] = 'Hello World 1!';
+      return testHelper.assertContextSuccess(
+        main.pollSftp({resources: ["arn:aws:events:us-east-1:1234567890:rule/test-stream1"]}, ctx),
+        ctx,
+        function(results) {
+          assert.equal(testHelper.s3.objects['my-bucket1/my-file.txt'], 'Hello World 1!');
+          assert.equal(testHelper.s3.objects['my-bucket2/subdir/my-file.txt'], 'Hello World 1!');
+        }
+      );
+    });
   });
 
   describe('#newS3Object()', function() {


### PR DESCRIPTION
# What
- Allows multiple `s3Locations` to be configured as a destinations and completes all copy tasks before moving the source SFTP file to the `.done` directory.

# Why
- When there are multiple streams configured for the same source SFTP directory, there is a race condition where the source file might get moved to the `.done` directory before the subsequent stream had a chance to finish copying it to the destination. 